### PR TITLE
Add python-markdown package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     sed -i 's/stretch /sid /g' /etc/apt/sources.list && \
     apt update -qq && \
     apt install -qqy --no-install-recommends ca-certificates  curl procps \
-                patch python uwsgi uwsgi-plugin-python \
+                patch python uwsgi uwsgi-plugin-python python-markdown \
                 $(apt -s dist-upgrade|awk '/^Inst.*ecurity/ {print $2}') &&\
     echo "downloading moin-${version}.tar.gz" && \
     curl -LOC- -s http://static.moinmo.in/files/moin-${version}.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # MoinMoin
 
-Moinmoin wiki on uWSGI docker container
+Moinmoin wiki on uWSGI docker container with Markdown.
+This is a fork of dperson/moinmoin, it just adds the python-markdown package so that pages using Markdown render correctly rather than generating a HTTP 503 error.
 
 # What is MoinMoin?
 


### PR DESCRIPTION
Add python-markdown debian package so that Markdown can be used in Wiki text. Otherwise pages using markdown will generate a HTTP 503 ERROR.